### PR TITLE
Handle the ERROR_RECOGNIZER_BUSY

### DIFF
--- a/src/android/com/pbakondy/SpeechRecognition.java
+++ b/src/android/com/pbakondy/SpeechRecognition.java
@@ -294,7 +294,7 @@ public class SpeechRecognition extends CordovaPlugin {
       // HACK: Swallow the `ERROR_RECOGNIZER_BUSY` non-critical error and we need to cancel the
       //   previous speech recognition trask if it exists:
       if (errorCode == SpeechRecognizer.ERROR_RECOGNIZER_BUSY) {
-        if(recognizer != null) {
+        if (recognizer != null) {
           recognizer.cancel();
         }
         return;

--- a/src/android/com/pbakondy/SpeechRecognition.java
+++ b/src/android/com/pbakondy/SpeechRecognition.java
@@ -292,7 +292,7 @@ public class SpeechRecognition extends CordovaPlugin {
       }
 
       // HACK: Swallow the `ERROR_RECOGNIZER_BUSY` non-critical error and we need to cancel the
-      //   previous speech recognition trask if it exists:
+      //   previous speech recognition task if it exists:
       if (errorCode == SpeechRecognizer.ERROR_RECOGNIZER_BUSY) {
         if (recognizer != null) {
           recognizer.cancel();

--- a/src/android/com/pbakondy/SpeechRecognition.java
+++ b/src/android/com/pbakondy/SpeechRecognition.java
@@ -291,6 +291,15 @@ public class SpeechRecognition extends CordovaPlugin {
         return;
       }
 
+      // HACK: Swallow the `ERROR_RECOGNIZER_BUSY` non-critical error and we need to cancel the
+      //   previous speech recognition trask if it exists:
+      if (errorCode == SpeechRecognizer.ERROR_RECOGNIZER_BUSY) {
+        if(recognizer != null) {
+          recognizer.cancel();
+        }
+        return;
+      }
+
       callbackContext.error(errorMessage);
     }
 


### PR DESCRIPTION
Swallow the non-critical ERROR_RECOGNIZER_BUSY error and cancel the previous speech recognition task if exists to start listening again without issues.